### PR TITLE
integration: langchain_xai

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -252,7 +252,7 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
     """  # noqa: E501
 
-    model_name: str = Field(alias="model")
+    model_name: str = Field(default="grok-beta",alias="model")
     """Model name to use."""
     xai_api_key: Optional[SecretStr] = Field(
         alias="api_key",


### PR DESCRIPTION
Adding a default parameter for model_name when no model provided may cause problems.

